### PR TITLE
Fix analytics imports and add poop timer tests

### DIFF
--- a/tests/test_ups_poop.py
+++ b/tests/test_ups_poop.py
@@ -1,0 +1,39 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def load_se_mi_ho():
+    module_path = Path(__file__).resolve().parent.parent / "ups_modul" / "poop" / "ups_poop.py"
+    source = module_path.read_text(encoding="utf-8")
+    module_ast = ast.parse(source, filename=str(module_path))
+
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "se_mi_ho":
+            func_module = ast.Module(body=[node], type_ignores=[])
+            compiled = compile(ast.fix_missing_locations(func_module), str(module_path), "exec")
+            namespace = {}
+            exec(compiled, namespace)
+            return namespace["se_mi_ho"]
+
+    raise AttributeError("se_mi_ho not found in ups_poop module")
+
+
+se_mi_ho = load_se_mi_ho()
+
+
+def test_se_mi_ho_returns_hours_minutes_seconds():
+    hours, minutes, seconds = se_mi_ho(3661)
+
+    assert hours == 1
+    assert minutes == 1
+    assert seconds == 1
+
+
+def test_se_mi_ho_preserves_fractional_seconds():
+    hours, minutes, seconds = se_mi_ho(7325.5)
+
+    assert hours == 2
+    assert minutes == 2
+    assert seconds == pytest.approx(5.5)

--- a/ups_anal/anal_heatmap/ups_plot_heatmap.py
+++ b/ups_anal/anal_heatmap/ups_plot_heatmap.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as pylot
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 from matplotlib import rcParams
 rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Roboto']

--- a/ups_anal/anal_heatmap/ups_plot_heatmap_personal.py
+++ b/ups_anal/anal_heatmap/ups_plot_heatmap_personal.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as pylot
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 from matplotlib import rcParams
 rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Roboto']

--- a/ups_anal/anal_heatmap_in_count/ups_plot_heatmap_in_count.py
+++ b/ups_anal/anal_heatmap_in_count/ups_plot_heatmap_in_count.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as pylot
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 from matplotlib import rcParams
 rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Roboto']

--- a/ups_anal/anal_heatmap_in_count/ups_plot_heatmap_personal_in_count.py
+++ b/ups_anal/anal_heatmap_in_count/ups_plot_heatmap_personal_in_count.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as pylot
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 from matplotlib import rcParams
 rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Roboto']

--- a/ups_anal/anal_heatmap_out_count/ups_plot_heatmap_out_count.py
+++ b/ups_anal/anal_heatmap_out_count/ups_plot_heatmap_out_count.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as pylot
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 from matplotlib import rcParams
 rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Roboto']

--- a/ups_anal/anal_heatmap_out_count/ups_plot_heatmap_personal_out_count.py
+++ b/ups_anal/anal_heatmap_out_count/ups_plot_heatmap_personal_out_count.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as pylot
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 from matplotlib import rcParams
 rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Roboto']

--- a/ups_anal/ups_anal.py
+++ b/ups_anal/ups_anal.py
@@ -1,4 +1,4 @@
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 import time
 file_name = 'inout_0.4_test.txt'
 

--- a/ups_anal/ups_data.py
+++ b/ups_anal/ups_data.py
@@ -1,4 +1,4 @@
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 import time
 file_name = 'inout_0.4_test.txt'
 

--- a/ups_anal/ups_parse_second_heatmap.py
+++ b/ups_anal/ups_parse_second_heatmap.py
@@ -1,5 +1,5 @@
 import time
-from ups_byt_test import *
+from ups_modul.inout.ups_byt import *
 from datetime import timedelta
 
 

--- a/ups_modul/inout/write_oled.py
+++ b/ups_modul/inout/write_oled.py
@@ -196,7 +196,7 @@ def write_4l(text, text2, text3, text4):
     # Draw a black filled box to clear the image.
     draw.rectangle((0,0,width,height), outline=0, fill=0)
 
-    # Write two lines of text.
+    # Write four lines of text.
 
     draw.text((x, top),        text,  font=font, fill=255)
     draw.text((x, top+8),      text2, font=font, fill=255)

--- a/ups_modul/poop/ups_poop.py
+++ b/ups_modul/poop/ups_poop.py
@@ -5,7 +5,7 @@ from phue import Bridge
 from ups_keys import *
 
 
-# conenct to HUE. press the button on the bridge
+# connect to HUE. press the button on the bridge
 def connect_HUE(bridge_ip):
     b = Bridge(bridge_ip)
     b.connect()
@@ -63,31 +63,36 @@ def poop_tweet(hours, minutes, seconds):
     return poop_tweet_time
 
 # pushing the tweet to twitter
+api = None
+
+
 def push_tweet(poop_tweet_time):
-    authenficate()
+    global api
+    if api is None:
+        api = authenficate()
     api.update_status(poop_tweet_time)
 
 
-poop_status = 0
-b = connect_HUE(bridge_ip)
-api = authenficate()
+if __name__ == "__main__":
+    poop_status = 0
+    b = connect_HUE(bridge_ip)
+    api = authenficate()
 
-
-# main loop with sleep time 0.5 seconds
-# def poop_loop():
-while True:
-    time.sleep(0.5)
-    light_status = get_light_status(b)
-    if light_status == 1 and poop_status == 0:
-        t1 = time.time()
-        poop_on_log(t1)
-        # cloud_log(poop_status)
-        poop_status = 1
-    elif light_status == 0 and poop_status == 1:
-        t2, t_delta = poop_timer(t1)
-        poop_off_log(t2)
-        # cloud_log(poop_status)
-        hours, minutes, seconds = se_mi_ho(t_delta)
-        poop_tweet_time = poop_tweet(hours, minutes, seconds)
-        push_tweet(poop_tweet_time)
-        poop_status = 0
+    # main loop with sleep time 0.5 seconds
+    # def poop_loop():
+    while True:
+        time.sleep(0.5)
+        light_status = get_light_status(b)
+        if light_status == 1 and poop_status == 0:
+            t1 = time.time()
+            poop_on_log(t1)
+            # cloud_log(poop_status)
+            poop_status = 1
+        elif light_status == 0 and poop_status == 1:
+            t2, t_delta = poop_timer(t1)
+            poop_off_log(t2)
+            # cloud_log(poop_status)
+            hours, minutes, seconds = se_mi_ho(t_delta)
+            poop_tweet_time = poop_tweet(hours, minutes, seconds)
+            push_tweet(poop_tweet_time)
+            poop_status = 0


### PR DESCRIPTION
## Summary
- replace references to the missing `ups_byt_test` module with the real `ups_modul.inout.ups_byt`
- make the Hue script import-safe, fixing the Hue connection typo and lazily initializing the Twitter client
- correct the OLED four-line comment and add pytest coverage for `se_mi_ho`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68bdb3e9d5b88332abfa7b0939b7822d